### PR TITLE
now can process input of arbitrary size

### DIFF
--- a/model_zoo/ffc.py
+++ b/model_zoo/ffc.py
@@ -103,10 +103,11 @@ class SpectralTransform(nn.Module):
         if self.enable_lfu:
             n, c, h, w = x.shape
             split_no = 2
-            split_s = h // split_no
+            split_s_h = h // split_no
+            split_s_w = w // split_no
             xs = torch.cat(torch.split(
-                x[:, :c // 4], split_s, dim=-2), dim=1).contiguous()
-            xs = torch.cat(torch.split(xs, split_s, dim=-1),
+                x[:, :c // 4], split_s_h, dim=-2), dim=1).contiguous()
+            xs = torch.cat(torch.split(xs, split_s_w, dim=-1),
                            dim=1).contiguous()
             xs = self.lfu(xs)
             xs = xs.repeat(1, 1, split_no, split_no).contiguous()


### PR DESCRIPTION
Before there was a bug that the input had to be square (B,C,N,N). The reason was in incorrect split size. Now it is possible  to process input of arbitrary size (B,C,N,M). 